### PR TITLE
chore: bump version number to 51.5.0 for latest-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforcedx",
-  "version": "51.4.0",
+  "version": "51.5.0",
   "description": "The Salesforce DX plugin aggregates all force topic commands into a single plugin that is bundled with the Salesforce CLI.",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",


### PR DESCRIPTION
### What does this PR do?
Bump version to 51.4.0 latest-rc
### What issues does this PR fix or reference?
