### PR TITLE
chore: bump apex version to 0.1.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "salesforce-alm"
   ],
   "dependencies": {
-    "@salesforce/plugin-apex": "0.1.20",
+    "@salesforce/plugin-apex": "0.1.21",
     "@salesforce/plugin-custom-metadata": "1.0.11",
     "@salesforce/plugin-data": "0.4.3",
     "@salesforce/plugin-limits": "1.0.4",


### PR DESCRIPTION
### What does this PR do?
This PR bumps the version of the Apex plugin to v0.1.21. This version includes the new force:apex:test:run and force:apex:test:report command.

We'd like this to be merged for the Thursday, April 8th release

### What issues does this PR fix or reference?
@W-8911042@